### PR TITLE
Update Initialiser to set run! method on target gem

### DIFF
--- a/lib/kangaru/initialiser.rb
+++ b/lib/kangaru/initialiser.rb
@@ -4,6 +4,12 @@ module Kangaru
       root_file = caller[0].gsub(/:.*$/, "")
 
       Kangaru.application = Application.new(root_file:, namespace:).tap(&:setup)
+
+      namespace.module_eval do
+        def self.run!(argv)
+          Kangaru.application.run!(argv)
+        end
+      end
     end
   end
 end

--- a/spec/features/initialiser_spec.rb
+++ b/spec/features/initialiser_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe "Initialising Kangaru in a target gem", :with_gem do
     it "does not set the Kangaru application reference" do
       expect { require_gem }.not_to change { Kangaru.application }.from(nil)
     end
+
+    it "does not define the run! method in the gem's root module" do
+      require_gem
+      expect(SomeGem).not_to respond_to(:run!)
+    end
   end
 
   context "when the target gem extends the initialiser" do
@@ -68,6 +73,11 @@ RSpec.describe "Initialising Kangaru in a target gem", :with_gem do
         .to change { Kangaru.application }
         .from(nil)
         .to(a_kind_of(Kangaru::Application))
+    end
+
+    it "defines the run! method in the gem's root module" do
+      require_gem
+      expect(SomeGem).to respond_to(:run!)
     end
 
     describe "application reference" do


### PR DESCRIPTION
- Initialiser when extended, now defines the `run!` method on the gem's
  root namespace.
- This is simply a delegation to Kangaru.application.run!, but allows
  calling the application from the target gem's namespace
  (eg SomeGem.run!)
