### PR TITLE
Only allow config to be applied once

### DIFF
--- a/lib/kangaru/application.rb
+++ b/lib/kangaru/application.rb
@@ -23,10 +23,17 @@ module Kangaru
       block.call(config) if current_env?(env)
     end
 
+    def configured?
+      @configured == true
+    end
+
     def apply_config!
+      raise "config already applied" if configured?
+
       config.import_external_config!
 
       @database = setup_database!
+      @configured = true
     end
 
     def run!(argv)

--- a/sig/kangaru/application.rbs
+++ b/sig/kangaru/application.rbs
@@ -11,6 +11,8 @@ module Kangaru
 
     def configure: (?Symbol?) { (Config) -> void } -> void
 
+    def configured?: -> bool
+
     def apply_config!: -> void
 
     def run!: (Array[String]) -> void
@@ -19,6 +21,8 @@ module Kangaru
     def view_path: (controller: String, action: String, ?ext: Symbol?) -> Pathname
 
     private
+
+    @configured: bool
 
     def current_env?: (Symbol?) -> bool
 

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -27,90 +27,114 @@ RSpec.describe "configuration" do
     gem.main_file.write(main_file)
   end
 
-  context "when only one configuration call is made" do
-    let(:configuration) do
-      configure_block(env:) do
-        <<~RUBY
-          config.test.value = :#{value}
-        RUBY
-      end
-    end
-
-    let(:value) { :foobar }
-
-    context "and no env is specified" do
-      let(:env) { nil }
-
-      it "sets the specified configuration" do
-        gem.load!
-        expect(application_config).to eq(value:)
-      end
-    end
-
-    context "and env is specified", :stub_env do
-      let(:env) { :some_env }
-
-      context "and specified env is not current env" do
-        let(:current_env) { :another_env }
-
-        it "does not set the config" do
-          gem.load!
-          expect(application_config).to be_empty
+  describe "setting config" do
+    context "when only one configuration call is made" do
+      let(:configuration) do
+        configure_block(env:) do
+          <<~RUBY
+            config.test.value = :#{value}
+          RUBY
         end
       end
 
-      context "and specified env is current env" do
-        let(:current_env) { env }
+      let(:value) { :foobar }
 
-        it "sets the config" do
+      context "and no env is specified" do
+        let(:env) { nil }
+
+        it "sets the specified configuration" do
           gem.load!
           expect(application_config).to eq(value:)
+        end
+      end
+
+      context "and env is specified", :stub_env do
+        let(:env) { :some_env }
+
+        context "and specified env is not current env" do
+          let(:current_env) { :another_env }
+
+          it "does not set the config" do
+            gem.load!
+            expect(application_config).to be_empty
+          end
+        end
+
+        context "and specified env is current env" do
+          let(:current_env) { env }
+
+          it "sets the config" do
+            gem.load!
+            expect(application_config).to eq(value:)
+          end
+        end
+      end
+    end
+
+    context "when multiple configuration calls are made", :stub_env do
+      let(:configuration) do
+        <<~RUBY
+          #{base_configuration}
+          #{env_configuration}
+        RUBY
+      end
+
+      let(:base_configuration) do
+        configure_block(env: nil) do
+          <<~RUBY
+            config.test.value = :base
+          RUBY
+        end
+      end
+
+      let(:env_configuration) do
+        configure_block(env: configured_env) do
+          <<~RUBY
+            config.test.value = :env
+          RUBY
+        end
+      end
+
+      let(:configured_env) { :some_env }
+
+      context "and not in configured env" do
+        let(:current_env) { :another_env }
+
+        it "sets the base value" do
+          gem.load!
+          expect(application_config).to eq(value: :base)
+        end
+      end
+
+      context "and in configured env" do
+        let(:current_env) { configured_env }
+
+        it "sets the env overridden value" do
+          gem.load!
+          expect(application_config).to eq(value: :env)
         end
       end
     end
   end
 
-  context "when multiple configuration calls are made", :stub_env do
-    let(:configuration) do
-      <<~RUBY
-        #{base_configuration}
-        #{env_configuration}
-      RUBY
-    end
+  describe "applying config" do
+    subject(:apply_config!) { SomeGem.apply_config! }
 
-    let(:base_configuration) do
-      configure_block(env: nil) do
-        <<~RUBY
-          config.test.value = :base
-        RUBY
+    let(:configuration) { nil }
+
+    before { gem.load! }
+
+    context "when config is applied once" do
+      it "does not raise any errors" do
+        expect { apply_config! }.not_to raise_error
       end
     end
 
-    let(:env_configuration) do
-      configure_block(env: configured_env) do
-        <<~RUBY
-          config.test.value = :env
-        RUBY
-      end
-    end
+    context "when config is applied more than once" do
+      before { SomeGem.apply_config! }
 
-    let(:configured_env) { :some_env }
-
-    context "and not in configured env" do
-      let(:current_env) { :another_env }
-
-      it "sets the base value" do
-        gem.load!
-        expect(application_config).to eq(value: :base)
-      end
-    end
-
-    context "and in configured env" do
-      let(:current_env) { configured_env }
-
-      it "sets the env overridden value" do
-        gem.load!
-        expect(application_config).to eq(value: :env)
+      it "raise an error" do
+        expect { apply_config! }.to raise_error("config already applied")
       end
     end
   end


### PR DESCRIPTION
Ensures that services such as Sequel are only ever initialised once.
This is important as Sequel initialisation is not idempotent and can
only be ran once.
