### PR TITLE
Implement Kangaru.application!

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kangaru (0.1.0)
+    kangaru (0.1.1)
       colorize (~> 1.1)
       erb (~> 4.0)
       sequel (~> 5.72)

--- a/lib/kangaru.rb
+++ b/lib/kangaru.rb
@@ -29,10 +29,10 @@ module Kangaru
   end
 
   class << self
-    attr_writer :application
+    attr_accessor :application
 
-    def application
-      @application || raise("application not set")
+    def application!
+      application || raise("application not set")
     end
 
     def env=(value)

--- a/lib/kangaru/concerns/configurable.rb
+++ b/lib/kangaru/concerns/configurable.rb
@@ -14,7 +14,7 @@ module Kangaru
       end
 
       def config
-        Kangaru.application.config.for(self.class.configurator_name) ||
+        Kangaru.application!.config.for(self.class.configurator_name) ||
           raise("inferred configurator not set by application")
       end
     end

--- a/lib/kangaru/controller.rb
+++ b/lib/kangaru/controller.rb
@@ -30,7 +30,7 @@ module Kangaru
     private
 
     def view_path(file)
-      Kangaru.application.view_path(self.class.path, file)
+      Kangaru.application!.view_path(self.class.path, file)
     end
 
     def renderer_for(file)
@@ -43,9 +43,9 @@ module Kangaru
     # within the application namespace by delegating const lookups to said
     # namespace if the constant is not in scope from the current class.
     def self.const_missing(const)
-      return super unless Kangaru.application.namespace.const_defined?(const)
+      return super unless Kangaru.application!.namespace.const_defined?(const)
 
-      Kangaru.application.namespace.const_get(const)
+      Kangaru.application!.namespace.const_get(const)
     end
 
     private_class_method :const_missing

--- a/lib/kangaru/injected_methods.rb
+++ b/lib/kangaru/injected_methods.rb
@@ -1,23 +1,23 @@
 module Kangaru
   module InjectedMethods
     def run!(*argv)
-      Kangaru.application.run!(*argv)
+      Kangaru.application!.run!(*argv)
     end
 
     def config
-      Kangaru.application.config
+      Kangaru.application!.config
     end
 
     def configure(env = nil, &)
-      Kangaru.application.configure(env, &)
+      Kangaru.application!.configure(env, &)
     end
 
     def apply_config!
-      Kangaru.application.apply_config!
+      Kangaru.application!.apply_config!
     end
 
     def database
-      Kangaru.application.database
+      Kangaru.application!.database
     end
   end
 end

--- a/lib/kangaru/version.rb
+++ b/lib/kangaru/version.rb
@@ -1,3 +1,3 @@
 module Kangaru
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end

--- a/sig/kangaru.rbs
+++ b/sig/kangaru.rbs
@@ -10,8 +10,10 @@ module Kangaru
   module ClassMethods
     @loader: Zeitwerk::Loader
 
-    attr_accessor application: Application
+    attr_accessor application: Application?
     attr_accessor env: Symbol
+
+    def application!: -> Application
 
     def env?: (Symbol) -> bool
 

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "configuration" do
   subject(:application_config) do
-    Kangaru.application.config.test.serialise
+    Kangaru.application!.config.test.serialise
   end
 
   let(:configurator_class) do

--- a/spec/features/external_config_spec.rb
+++ b/spec/features/external_config_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "External application config" do
     gem.load!
   end
 
-  let(:external_config) { Kangaru.application.config.external.serialise }
+  let(:external_config) { Kangaru.application!.config.external.serialise }
 
   shared_examples :does_not_set_external_config do
     it "does not raise any errors" do

--- a/spec/features/initialiser_spec.rb
+++ b/spec/features/initialiser_spec.rb
@@ -35,8 +35,7 @@ RSpec.describe "Initialising Kangaru in a target gem" do
       end
 
       it "does not set the Kangaru application reference" do
-        require_gem
-        expect { Kangaru.application }.to raise_error("application not set")
+        expect { require_gem }.not_to change { Kangaru.application }.from(nil)
       end
 
       it "does not define the run! method in the gem's root module" do
@@ -71,8 +70,9 @@ RSpec.describe "Initialising Kangaru in a target gem" do
       end
 
       it "sets the Kangaru application reference" do
-        require_gem
-        expect(Kangaru.application).to be_a(Kangaru::Application)
+        expect { require_gem }
+          .to change { Kangaru.application }
+          .to be_a(Kangaru::Application)
       end
 
       it "defines the run! method in the gem's root module" do
@@ -81,7 +81,7 @@ RSpec.describe "Initialising Kangaru in a target gem" do
       end
 
       describe "application reference" do
-        subject(:application) { Kangaru.application }
+        subject(:application) { Kangaru.application! }
 
         before { require_gem }
 

--- a/spec/kangaru/concerns/configurable_spec.rb
+++ b/spec/kangaru/concerns/configurable_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Kangaru::Concerns::Configurable do
         .to receive(:application)
         .and_return(application)
 
-      allow(Kangaru.application)
+      allow(Kangaru.application!)
         .to receive(:config)
         .and_return(application_config)
 

--- a/spec/kangaru/initialiser_spec.rb
+++ b/spec/kangaru/initialiser_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe Kangaru::Initialiser do
       end
 
       it "sets the Kangaru application to the created application" do
-        extended
-        expect(Kangaru.application).to eq(application)
+        expect { extended }.to change { Kangaru.application }.to(application)
       end
 
       it "eager loads the Initialisers namespace" do

--- a/spec/kangaru_spec.rb
+++ b/spec/kangaru_spec.rb
@@ -21,8 +21,12 @@ RSpec.describe Kangaru do
     subject(:application) { described_class.application }
 
     context "when application is not set" do
-      it "raises an error" do
-        expect { application }.to raise_error("application not set")
+      it "does not raise any errors" do
+        expect { application }.not_to raise_error
+      end
+
+      it "returns nil" do
+        expect(application).to be_nil
       end
     end
 
@@ -41,6 +45,34 @@ RSpec.describe Kangaru do
 
       it "returns the application instance" do
         expect(application).to eq(instance)
+      end
+    end
+  end
+
+  describe "#application!" do
+    subject(:application!) { described_class.application! }
+
+    context "when application is not set" do
+      it "raises an error" do
+        expect { application! }.to raise_error("application not set")
+      end
+    end
+
+    context "when application is set" do
+      around do |spec|
+        described_class.instance_variable_set(:@application, instance)
+        spec.run
+        described_class.remove_instance_variable(:@application)
+      end
+
+      let(:instance) { instance_double(Kangaru::Application) }
+
+      it "does not raise any errors" do
+        expect { application! }.not_to raise_error
+      end
+
+      it "returns the application instance" do
+        expect(application!).to eq(instance)
       end
     end
   end


### PR DESCRIPTION
- Kangaru.application no longer raises an error if nil when called
- Kangaru.application! inherits the old behaviour and has been replaced in the codebase appropriately
- This is to allow checking whether Kangaru is initialised (by the presence of an application) without raising an error
