### PR TITLE
RSpec integration extensions

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -3,6 +3,8 @@ target :lib do
 
   check "lib"
 
+  ignore "lib/kangaru/initialisers/rspec*"
+
   configure_code_diagnostics do |hash|
     hash[Steep::Diagnostic::Ruby::FallbackAny] = nil
     hash[Steep::Diagnostic::Ruby::UnknownConstant] = :error

--- a/lib/kangaru/database.rb
+++ b/lib/kangaru/database.rb
@@ -31,7 +31,7 @@ module Kangaru
       Sequel::Migrator.run(handler, migration_path)
     end
 
-    def_delegators :handler, :tables
+    def_delegators :handler, :rollback_on_exit, :tables, :transaction
 
     private
 

--- a/lib/kangaru/initialisers/rspec.rb
+++ b/lib/kangaru/initialisers/rspec.rb
@@ -2,8 +2,14 @@ module Kangaru
   module Initialisers
     module RSpec
       if Object.const_defined?(:RSpec)
-        ::RSpec.configure do
+        ::RSpec.configure do |config|
           Kangaru.env = :test
+
+          config.include KangaruHelper
+
+          config.around do |spec|
+            run_in_transaction { spec.run }
+          end
         end
       end
     end

--- a/lib/kangaru/initialisers/rspec/kangaru_helper.rb
+++ b/lib/kangaru/initialisers/rspec/kangaru_helper.rb
@@ -1,0 +1,18 @@
+module Kangaru
+  module Initialisers
+    module RSpec
+      module KangaruHelper
+        def run_in_transaction(&block)
+          database = Kangaru.application&.database
+
+          return block.call if database.nil?
+
+          database.transaction do
+            block.call
+            database.rollback_on_exit
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kangaru/initialisers/rspec/request_helper.rb
+++ b/lib/kangaru/initialisers/rspec/request_helper.rb
@@ -2,6 +2,17 @@ module Kangaru
   module Initialisers
     module RSpec
       module RequestHelper
+        def stub_output(&block)
+          stdout  = $stdout
+          stderr  = $stderr
+          $stdout = File.open(File::NULL, "w")
+          $stderr = File.open(File::NULL, "w")
+
+          block.call
+
+          $stdout = stdout
+          $stderr = stderr
+        end
       end
 
       if Object.const_defined?(:RSpec)
@@ -13,6 +24,10 @@ module Kangaru
           end
 
           config.include RequestHelper, type: :request
+
+          config.around(type: :request) do |spec|
+            stub_output { spec.run }
+          end
         end
       end
     end

--- a/lib/kangaru/initialisers/rspec/request_helper.rb
+++ b/lib/kangaru/initialisers/rspec/request_helper.rb
@@ -1,0 +1,20 @@
+module Kangaru
+  module Initialisers
+    module RSpec
+      module RequestHelper
+      end
+
+      if Object.const_defined?(:RSpec)
+        ::RSpec.configure do |config|
+          file_path = %r{spec/.*/controllers/}
+
+          config.define_derived_metadata(file_path:) do |metadata|
+            metadata[:type] = :request
+          end
+
+          config.include RequestHelper, type: :request
+        end
+      end
+    end
+  end
+end

--- a/lib/kangaru/initialisers/rspec/request_helper.rb
+++ b/lib/kangaru/initialisers/rspec/request_helper.rb
@@ -2,6 +2,8 @@ module Kangaru
   module Initialisers
     module RSpec
       module RequestHelper
+        attr_reader :request
+
         def stub_output(&block)
           stdout  = $stdout
           stderr  = $stderr
@@ -12,6 +14,18 @@ module Kangaru
 
           $stdout = stdout
           $stderr = stderr
+        end
+
+        def resolve(path, params:)
+          @request = Kangaru::Request.new(path:, params:)
+
+          Kangaru.application.router.resolve(request)
+        end
+
+        private
+
+        def view_path(name)
+          Kangaru.application!.view_path(described_class.path, name.to_s)
         end
       end
 

--- a/sig/kangaru/database.rbs
+++ b/sig/kangaru/database.rbs
@@ -18,7 +18,9 @@ module Kangaru
     def migrate!: -> void
 
     # Delegated to handler
+    def rollback_on_exit: -> void
     def tables: -> Array[Symbol]
+    def transaction: { -> void } -> void
 
     private
 


### PR DESCRIPTION
- Do not type initialisers/rspec files
- Add more Database delegations
- Configure RSpec to rollback database operations
- Create RequestHelper
- Ensure request specs stub output
- Implement RequestHelper#resolve
- Add render_template request matcher
