### PR TITLE
v0.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kangaru (0.1.1)
+    kangaru (0.1.2)
       colorize (~> 1.1)
       erb (~> 4.0)
       sequel (~> 5.72)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Kangaru is an open-source framework written in Ruby for building powerful and efficient command line applications. This project aims to make it easier for developers to create complex CLI programs with minimal effort, by providing a set of useful tools and libraries in a configurable ecosystem.
 
-> Note: This software is currently in beta mode, meaning it may contain bugs and be subject to changes. Please exercise caution when using this software and report any issues you encounter. The first production-ready release of Kangaru will be version 0.2.0.
+> Note: This software is currently in beta mode, meaning it may contain bugs and be subject to changes. Please exercise caution when using this software and report any issues you encounter. The first production-ready release of Kangaru will be version 1.0.0.
 
 ## Features
 

--- a/kangaru.gemspec
+++ b/kangaru.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |spec|
   spec.email = ["71787007+apexatoll@users.noreply.github.com"]
 
   spec.summary = "A lightweight framework for building command line interfaces"
+  spec.homepage = "https://github.com/apexatoll/kangaru"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
 
@@ -15,6 +16,11 @@ Gem::Specification.new do |spec|
       f == __FILE__ || f.match?(/\A(bin|spec|\.git|\.github)/)
     end
   end
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/releases"
+
   spec.bindir = "bin"
   spec.executables = []
   spec.require_paths = ["lib"]

--- a/lib/kangaru/initialisers/rspec/request_helper.rb
+++ b/lib/kangaru/initialisers/rspec/request_helper.rb
@@ -2,8 +2,6 @@ module Kangaru
   module Initialisers
     module RSpec
       module RequestHelper
-        extend ::RSpec::Matchers::DSL
-
         attr_reader :request
 
         def stub_output(&block)
@@ -28,24 +26,28 @@ module Kangaru
           Kangaru.application!.view_path(described_class.path, name.to_s)
         end
 
-        matcher :render_template do |name|
-          supports_block_expectations
+        if Object.const_defined?(:RSpec)
+          extend ::RSpec::Matchers::DSL
 
-          match do |action|
-            renderer = instance_double(Kangaru::Renderer, render: nil)
-            allow(Kangaru::Renderer).to receive(:new).and_return(renderer)
-            expect(Kangaru::Renderer).not_to have_received(:new)
+          matcher :render_template do |name|
+            supports_block_expectations
 
-            action.call
+            match do |action|
+              renderer = instance_double(Kangaru::Renderer, render: nil)
+              allow(Kangaru::Renderer).to receive(:new).and_return(renderer)
+              expect(Kangaru::Renderer).not_to have_received(:new)
 
-            expect(Kangaru::Renderer)
-              .to have_received(:new)
-              .with(view_path(name))
-              .once
+              action.call
 
-            expect(renderer)
-              .to have_received(:render)
-              .once
+              expect(Kangaru::Renderer)
+                .to have_received(:new)
+                .with(view_path(name))
+                .once
+
+              expect(renderer)
+                .to have_received(:render)
+                .once
+            end
           end
         end
       end

--- a/lib/kangaru/version.rb
+++ b/lib/kangaru/version.rb
@@ -1,3 +1,3 @@
 module Kangaru
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end


### PR DESCRIPTION
- Fixes a bug in which loading the application would load the RequestHelper but then error due to not finding the DSL module/matcher interface.
- This PR only conditionally defines this part of the RequestHelper if RSpec is initialised in the Runtime
