### PR TITLE
Fix blank external config bug

### DIFF
--- a/lib/kangaru/configurators/open_configurator.rb
+++ b/lib/kangaru/configurators/open_configurator.rb
@@ -16,7 +16,7 @@ module Kangaru
       def self.from_yaml_file(path)
         raise "path does not exist" unless File.exist?(path)
 
-        attributes = YAML.load_file(path).symbolise
+        attributes = YAML.load_file(path)&.symbolise || {}
 
         new(**attributes)
       end

--- a/spec/features/external_config_spec.rb
+++ b/spec/features/external_config_spec.rb
@@ -66,17 +66,25 @@ RSpec.describe "External application config" do
     end
 
     context "and config exists at the specified path" do
-      let(:config_file) do
-        <<~YAML
-          frodo:
-            race: hobbit
-            age: 48
-        YAML
-      end
-
       before { config_path.write(config_file) }
 
-      include_examples :sets_external_config
+      context "and config file is empty", skip: :bug_fix do
+        let(:config_file) { "" }
+
+        include_examples :does_not_set_external_config
+      end
+
+      context "and config file is not empty" do
+        let(:config_file) do
+          <<~YAML
+            frodo:
+              race: hobbit
+              age: 48
+          YAML
+        end
+
+        include_examples :sets_external_config
+      end
     end
   end
 end

--- a/spec/features/external_config_spec.rb
+++ b/spec/features/external_config_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "External application config" do
     context "and config exists at the specified path" do
       before { config_path.write(config_file) }
 
-      context "and config file is empty", skip: :bug_fix do
+      context "and config file is empty" do
         let(:config_file) { "" }
 
         include_examples :does_not_set_external_config

--- a/spec/kangaru/configurators/open_configurator_spec.rb
+++ b/spec/kangaru/configurators/open_configurator_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Kangaru::Configurators::OpenConfigurator do
     context "when specified file exists" do
       let(:exists?) { true }
 
-      context "and file is empty", skip: :bug_fix do
+      context "and file is empty" do
         let(:string_hash) { nil }
 
         it "does not raise any errors" do

--- a/spec/kangaru/configurators/open_configurator_spec.rb
+++ b/spec/kangaru/configurators/open_configurator_spec.rb
@@ -35,16 +35,32 @@ RSpec.describe Kangaru::Configurators::OpenConfigurator do
     context "when specified file exists" do
       let(:exists?) { true }
 
-      it "does not raise any errors" do
-        expect { open_configurator }.not_to raise_error
+      context "and file is empty", skip: :bug_fix do
+        let(:string_hash) { nil }
+
+        it "does not raise any errors" do
+          expect { open_configurator }.not_to raise_error
+        end
+
+        it "returns an OpenConfigurator" do
+          expect(open_configurator).to be_a(described_class)
+        end
       end
 
-      it "returns an OpenConfigurator" do
-        expect(open_configurator).to be_a(described_class)
-      end
+      context "and file is not empty" do
+        let(:string_hash) { { "foo" => "foo", "bar" => "bar", "baz" => "baz" } }
 
-      it "parses and sets the attributes" do
-        expect(open_configurator).to have_attributes(**expected_attributes)
+        it "does not raise any errors" do
+          expect { open_configurator }.not_to raise_error
+        end
+
+        it "returns an OpenConfigurator" do
+          expect(open_configurator).to be_a(described_class)
+        end
+
+        it "parses and sets the attributes" do
+          expect(open_configurator).to have_attributes(**expected_attributes)
+        end
       end
     end
   end


### PR DESCRIPTION
- This PR fixes a bug where a target application that sets an external config file, but the file is blank, will raise an error when applying application config
- This is due to `YAML.load_file` unexpectedly returning `nil` rather than an empty hash when the file is empty
