### PR TITLE
Configurator validation

### DIFF
--- a/lib/kangaru/application.rb
+++ b/lib/kangaru/application.rb
@@ -2,6 +2,8 @@ module Kangaru
   class Application
     extend Forwardable
 
+    class InvalidConfigError < StandardError; end
+
     attr_reader :paths, :namespace, :database
 
     attr_accessor :config_path
@@ -38,6 +40,8 @@ module Kangaru
 
       config.import!(config_path) unless config_path.nil?
 
+      validate_config!
+
       @database = setup_database!
       @configured = true
     end
@@ -71,6 +75,14 @@ module Kangaru
         loader.collapse(paths.collapsed_dirs)
         loader.push_dir(paths.lib_path.to_s)
       end
+    end
+
+    def validate_config!
+      return if config.valid?
+
+      message = config.errors.map(&:full_message).join(", ")
+
+      raise InvalidConfigError, message
     end
 
     def setup_database!

--- a/lib/kangaru/config.rb
+++ b/lib/kangaru/config.rb
@@ -22,6 +22,19 @@ module Kangaru
       configurators[key.to_sym]
     end
 
+    def valid?
+      validate
+      errors.empty?
+    end
+
+    def validate
+      configurators.each_value(&:validate)
+    end
+
+    def errors
+      configurators.values.flat_map(&:errors)
+    end
+
     private
 
     def set_configurators!

--- a/lib/kangaru/configurator.rb
+++ b/lib/kangaru/configurator.rb
@@ -1,6 +1,7 @@
 module Kangaru
   class Configurator
     include Concerns::AttributesConcern
+    include Concerns::Validatable
 
     using Patches::Inflections
 

--- a/sig/kangaru/application.rbs
+++ b/sig/kangaru/application.rbs
@@ -2,6 +2,9 @@ module Kangaru
   class Application
     extend Forwardable
 
+    class InvalidConfigError < StandardError
+    end
+
     attr_reader paths: Paths
     attr_reader namespace: Module
     attr_reader config: Config
@@ -33,6 +36,8 @@ module Kangaru
     def current_env?: (Symbol?) -> bool
 
     attr_reader autoloader: Zeitwerk::Loader
+
+    def validate_config!: -> void
 
     def setup_database!: -> Database?
   end

--- a/sig/kangaru/config.rbs
+++ b/sig/kangaru/config.rbs
@@ -10,6 +10,12 @@ module Kangaru
 
     def []: (Symbol) -> Configurator?
 
+    def valid?: -> bool
+
+    def validate: -> void
+
+    def errors: -> Array[Validation::Error]
+
     # Native Configurators
     attr_reader database: Configurators::DatabaseConfigurator
     attr_reader request:  Configurators::RequestConfigurator

--- a/sig/kangaru/configurator.rbs
+++ b/sig/kangaru/configurator.rbs
@@ -3,6 +3,9 @@ module Kangaru
     include Concerns::AttributesConcern
     extend  Concerns::AttributesConcern::ClassMethods
 
+    include Concerns::Validatable
+    extend  Concerns::Validatable::ClassMethods
+
     def self.key: -> Symbol
 
     def self.name: -> String


### PR DESCRIPTION
# Configurator Validation

- This PR implements the abilty to define and execute validations for Configurator objects
- This is mediated through the existing Validatable concern
- The Config class has been updated to define a similar validation interface, by delegating and iterating through the configurator validations
- The apply_config! method was also updated to integrate validation as part of application initialisation
