### PR TITLE
Allow env-dependent config file paths

### DIFF
--- a/lib/kangaru/interface.rb
+++ b/lib/kangaru/interface.rb
@@ -8,7 +8,7 @@ module Kangaru
       Kangaru.application!.config
     end
 
-    def configure(env = nil, &)
+    def configure(env: nil, &)
       return unless env_applies?(env)
 
       Kangaru.application!.configure(&)

--- a/lib/kangaru/interface.rb
+++ b/lib/kangaru/interface.rb
@@ -14,7 +14,7 @@ module Kangaru
       Kangaru.application!.configure(&)
     end
 
-    def import_config_from!(path)
+    def config_path(path)
       Kangaru.application!.config_path = path
     end
 

--- a/lib/kangaru/interface.rb
+++ b/lib/kangaru/interface.rb
@@ -9,7 +9,7 @@ module Kangaru
     end
 
     def configure(env = nil, &)
-      return if env && !Kangaru.env?(env)
+      return unless env_applies?(env)
 
       Kangaru.application!.configure(&)
     end
@@ -24,6 +24,14 @@ module Kangaru
 
     def database
       Kangaru.application!.database
+    end
+
+    private
+
+    def env_applies?(env)
+      return true if env.nil?
+
+      Kangaru.env?(env)
     end
   end
 end

--- a/lib/kangaru/interface.rb
+++ b/lib/kangaru/interface.rb
@@ -14,7 +14,9 @@ module Kangaru
       Kangaru.application!.configure(&)
     end
 
-    def config_path(path)
+    def config_path(path, env: nil)
+      return unless env_applies?(env)
+
       Kangaru.application!.config_path = path
     end
 

--- a/sig/kangaru/interface.rbs
+++ b/sig/kangaru/interface.rbs
@@ -4,7 +4,7 @@ module Kangaru
 
     def config: -> Config
 
-    def configure: (?Symbol?) { (Config) -> void } -> void
+    def configure: (?env: Symbol?) { (Config) -> void } -> void
 
     def apply_config!: -> void
 

--- a/sig/kangaru/interface.rbs
+++ b/sig/kangaru/interface.rbs
@@ -8,7 +8,7 @@ module Kangaru
 
     def apply_config!: -> void
 
-    def import_config_from!: (String) -> void
+    def config_path: (String) -> void
 
     def database: -> Database?
 

--- a/sig/kangaru/interface.rbs
+++ b/sig/kangaru/interface.rbs
@@ -11,5 +11,9 @@ module Kangaru
     def import_config_from!: (String) -> void
 
     def database: -> Database?
+
+    private
+
+    def env_applies?: (Symbol?) -> bool
   end
 end

--- a/sig/kangaru/interface.rbs
+++ b/sig/kangaru/interface.rbs
@@ -1,14 +1,16 @@
 module Kangaru
   module Interface
+    type env = Symbol?
+
     def run!: (*String) -> void
 
     def config: -> Config
 
-    def configure: (?env: Symbol?) { (Config) -> void } -> void
+    def configure: (?env: env) { (Config) -> void } -> void
 
     def apply_config!: -> void
 
-    def config_path: (String) -> void
+    def config_path: (String, ?env: env) -> void
 
     def database: -> Database?
 

--- a/spec/features/importing_config_spec.rb
+++ b/spec/features/importing_config_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "importing external config" do
       module SomeGem
         extend Kangaru::Initialiser
 
-        import_config_from! "#{config_path}"
+        config_path "#{config_path}"
 
         apply_config!
       end

--- a/spec/kangaru/interface_spec.rb
+++ b/spec/kangaru/interface_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Kangaru::Interface, :stub_application do
   end
 
   describe "#configure" do
-    subject(:configure) { target.configure(env, &block) }
+    subject(:configure) { target.configure(env:, &block) }
 
     let(:block) { ->(_config) { :config } }
 

--- a/spec/kangaru/interface_spec.rb
+++ b/spec/kangaru/interface_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe Kangaru::Interface, :stub_application do
     end
   end
 
-  describe "#import_config_from!" do
-    subject(:import_config_from!) { target.import_config_from!(path) }
+  describe "#config_path" do
+    subject(:config_path) { target.config_path(path) }
 
     let(:path) { "/foo/bar/config.yml" }
 

--- a/spec/support/features/configuration_helper.rb
+++ b/spec/support/features/configuration_helper.rb
@@ -1,7 +1,7 @@
 module ConfigurationHelper
   def configure_block(env: nil)
     <<~RUBY
-      configure #{env && ":#{env}"} do |config|
+      configure #{env && "env: :#{env}"} do |config|
         #{yield}
       end
     RUBY


### PR DESCRIPTION
- Refactor Interface
- Rename import_config_from! Interface method to config_path
- Change env argument to a keyword arg
- Update config path to be env dependent
