### PR TITLE
Improve request specs

### DIFF
--- a/lib/kangaru/initialisers/rspec/request_helper.rb
+++ b/lib/kangaru/initialisers/rspec/request_helper.rb
@@ -62,7 +62,7 @@ module Kangaru
 
           config.include RequestHelper, type: :request
 
-          config.around(type: :request) do |spec|
+          config.around(stub_output: true) do |spec|
             stub_output { spec.run }
           end
         end

--- a/lib/kangaru/router.rb
+++ b/lib/kangaru/router.rb
@@ -21,7 +21,7 @@ module Kangaru
     private
 
     def controller_class
-      @controller_class ||= request.controller.constantise(root: namespace)
+      request.controller.constantise(root: namespace)
     end
 
     def validate_controller_defined!

--- a/sig/kangaru/router.rbs
+++ b/sig/kangaru/router.rbs
@@ -11,8 +11,6 @@ module Kangaru
 
     private
 
-    @controller_class: untyped
-
     def controller_class: -> untyped
 
     def validate_controller_defined!: -> void

--- a/sig/kangaru/router.rbs
+++ b/sig/kangaru/router.rbs
@@ -13,10 +13,6 @@ module Kangaru
 
     @controller_class: untyped
 
-    # Delegated to command
-    def controller_name: -> String
-    def action: -> Symbol
-
     def controller_class: -> untyped
 
     def validate_controller_defined!: -> void


### PR DESCRIPTION
- Do not cache Router#controller_class
  * This was causing issues in request specs in target applications, in that making a request to a controller after initially making a request to another controller was failing
  * Caching the controller_class meant that the initial controller was attempted to be used for both requests

- Opt in to stubbing request spec output
  * This was difficult to debug
